### PR TITLE
Update repository link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["haydn@tinychain.net"]
 edition = "2018"
 license = "Apache-2.0"
 description = "An in-memory filesystem cache layer over tokio::fs, with LFU eviction"
-repository = "https://github.com/haydnv/freqache"
+repository = "https://github.com/haydnv/freqfs"
 readme = "README.md"
 
 categories = ["caching", "filesystem", "memory-management"]


### PR DESCRIPTION
crates.io for this package was pointing to a different repo. This should fix it.